### PR TITLE
Update release workflow to trigger on published releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,15 +3,13 @@ name: "Release Binaries"
 
 # yamllint disable-line rule:truthy
 on:
-  workflow_run:
-    workflows: ["Semantic Release"]
-    types: ["completed"]
-    branches: ["main"]
+  release:
+    types: ["published"]
 
 jobs:
   build:
-    # Only run if the semantic-release workflow succeeded
-    if: "${{ github.event.workflow_run.conclusion == 'success' }}"
+    # Only run for non-draft, non-prerelease releases
+    if: "${{ !github.event.release.draft && !github.event.release.prerelease }}"
     permissions:
       contents: "write"
     runs-on: "ubuntu-latest"
@@ -19,7 +17,7 @@ jobs:
       - name: "Checkout repository"
         uses: "actions/checkout@v4"
         with:
-          ref: "${{ github.event.workflow_run.head_sha }}"
+          ref: "${{ github.event.release.tag_name }}"
 
       - name: "Setup Deno"
         uses: "denoland/setup-deno@v2"
@@ -40,7 +38,7 @@ jobs:
 
   upload:
     needs: "build"
-    if: "${{ github.event.workflow_run.conclusion == 'success' }}"
+    if: "${{ !github.event.release.draft && !github.event.release.prerelease }}"
     permissions:
       contents: "write"
     runs-on: "ubuntu-latest"
@@ -64,24 +62,13 @@ jobs:
           name: "binaries"
           path: "./dist"
 
-      - name: "Get latest release"
-        id: "get_release"
-        uses: "actions/github-script@v7"
-        with:
-          script: |
-            const release = await github.rest.repos.getLatestRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            });
-            return release.data;
-
       - name: "Upload ${{ matrix.platform }} binary"
         uses: "actions/upload-release-asset@v1"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         # yamllint disable rule:line-length
         with:
-          upload_url: "${{ fromJSON(steps.get_release.outputs.result).upload_url }}"
+          upload_url: "${{ github.event.release.upload_url }}"
           asset_path: "./dist/cosmo-trigger-${{ matrix.platform }}${{ matrix.extension }}"
           asset_name: "cosmo-trigger-${{ matrix.platform }}${{ matrix.extension }}"
           # yamllint enable rule:line-length


### PR DESCRIPTION
The release of the artifact is now triggered when a new version appears. See: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release